### PR TITLE
Add live throughput meter (per-NIC: VPN tunnel, WAN outflow, LAN inflow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>Pi-Powered VPN Client Gateway</h1>
-The VPN Client Gateway forwards network traffic through a Virtual Private Network connection. To facilitate geospoofing for media streaming, it includes a management web page that allows you to switch VPN servers by simply clicking on a country flag.
+The VPN Client Gateway forwards network traffic through a Virtual Private Network connection. To facilitate geospoofing for media streaming, it includes a management web page that allows you to switch VPN servers by simply clicking on a country flag. The management page also shows a live **throughput meter** with download/upload rates for the VPN tunnel and for the gateway as a whole.
 
 To build your own VPN Client Gateway you will need a Raspberry Pi (or similar lightweight Linux computer) and a [Private Internet Access](https://www.privateinternetaccess.com), [PureVPN](https://www.purevpn.com/), [Newshosting](https://www.newshosting.com/), or [NordVPN](https://www.nordvpn.com/) VPN account.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>Pi-Powered VPN Client Gateway</h1>
-The VPN Client Gateway forwards network traffic through a Virtual Private Network connection. To facilitate geospoofing for media streaming, it includes a management web page that allows you to switch VPN servers by simply clicking on a country flag. The management page also shows a live **throughput meter** with download/upload rates for the VPN tunnel and for the gateway as a whole.
+The VPN Client Gateway forwards network traffic through a Virtual Private Network connection. To facilitate geospoofing for media streaming, it includes a management web page that allows you to switch VPN servers by simply clicking on a country flag. The management page also shows a live **throughput meter** with per-interface RX/TX rates — the VPN tunnel plus each physical NIC, labelled by role (the WAN/uplink that carries traffic out to the internet vs. the LAN, client-facing NICs).
 
 To build your own VPN Client Gateway you will need a Raspberry Pi (or similar lightweight Linux computer) and a [Private Internet Access](https://www.privateinternetaccess.com), [PureVPN](https://www.purevpn.com/), [Newshosting](https://www.newshosting.com/), or [NordVPN](https://www.nordvpn.com/) VPN account.
 

--- a/documentation/IMPLEMENTATION_NOTES.md
+++ b/documentation/IMPLEMENTATION_NOTES.md
@@ -158,3 +158,33 @@ the shared `10.5.0.2/32` source address across simultaneous NordLynx tunnels.
 * GitHub Actions CI on PR #2: both check runs reported **success**.
 * PR #2 is documentation-only, so the single-tunnel runtime behaviour is
   unchanged and there is no code regression surface.
+
+## Throughput meter (live, on the management page)
+
+The management page shows a live **Throughput** panel under "Current VPN server"
+with download/upload rates for two things:
+
+* **VPN tunnel** — the active VPN interface (`wg0` for WireGuard, `tun0` for
+  OpenVPN, via `vpn_iface()`); shown as "VPN off" when the gateway is disabled.
+* **Whole box** — the primary physical NIC (auto-detected, defaults to `eth0`),
+  which carries all traffic in and out of the gateway.
+
+Key design points:
+
+1. **No new privileges.** Counters are read from `/proc/net/dev`, which is
+   world-readable, so the meter needs no `sudo`, touches no firewall/kill-switch
+   state, and is independent of the WireGuard/OpenVPN backend plumbing.
+2. **Rates are computed in the browser** from two successive samples. The
+   endpoint (`www/vpnmgmt/throughput.php`) returns only the cumulative byte
+   counters plus a server timestamp as JSON; the page polls every ~2 s and
+   derives `Δbytes / Δt`. No server-side state and no blocking `sleep`.
+3. **Robustness.** A negative delta (counter reset when an interface bounces) is
+   suppressed; polling pauses while the browser tab is backgrounded
+   (`document.hidden`); the first sample just primes the baseline.
+4. **Testable core.** Parsing of `/proc/net/dev` and the "which interface is the
+   box" choice live in pure functions (`www/vpnmgmt/netstat.php`) covered by
+   `tests/test_netstat.php`.
+
+Files: added `www/vpnmgmt/netstat.php`, `www/vpnmgmt/throughput.php`,
+`tests/test_netstat.php`; edited `www/index.php` (panel + poller),
+`www/index.css` (panel styles) and `tests/run.sh` (run the new tests).

--- a/documentation/IMPLEMENTATION_NOTES.md
+++ b/documentation/IMPLEMENTATION_NOTES.md
@@ -162,18 +162,27 @@ the shared `10.5.0.2/32` source address across simultaneous NordLynx tunnels.
 ## Throughput meter (live, on the management page)
 
 The management page shows a live **Throughput** panel under "Current VPN server"
-with download/upload rates for two things:
+with per-interface RX/TX rates, each row tagged by role:
 
 * **VPN tunnel** — the active VPN interface (`wg0` for WireGuard, `tun0` for
   OpenVPN, via `vpn_iface()`); shown as "VPN off" when the gateway is disabled.
-* **Whole box** — the primary physical NIC (auto-detected, defaults to `eth0`),
-  which carries all traffic in and out of the gateway.
+* **WAN (outflow)** — the physical uplink to the internet, identified as the
+  interface that holds the main-table default route (parsed from
+  `/proc/net/route`; the VPN tunnel is ignored so we report the *physical* NIC
+  even while the tunnel owns the effective default).
+* **LAN (inflow)** — every other physical NIC (client-facing). On a multi-NIC
+  box these are separate rows; on a single-NIC box there is just the one
+  physical NIC, reported as the WAN/uplink (it carries LAN traffic too).
+
+Virtual/bridge/container interfaces (`lo`, `veth*`, `docker*`, `br-*`, other
+`tun*`/`wg*`, …) are excluded.
 
 Key design points:
 
-1. **No new privileges.** Counters are read from `/proc/net/dev`, which is
-   world-readable, so the meter needs no `sudo`, touches no firewall/kill-switch
-   state, and is independent of the WireGuard/OpenVPN backend plumbing.
+1. **No new privileges.** Counters come from `/proc/net/dev` and the route table
+   from `/proc/net/route`, both world-readable, so the meter needs no `sudo`,
+   touches no firewall/kill-switch state, and is independent of the
+   WireGuard/OpenVPN backend plumbing.
 2. **Rates are computed in the browser** from two successive samples. The
    endpoint (`www/vpnmgmt/throughput.php`) returns only the cumulative byte
    counters plus a server timestamp as JSON; the page polls every ~2 s and
@@ -181,9 +190,9 @@ Key design points:
 3. **Robustness.** A negative delta (counter reset when an interface bounces) is
    suppressed; polling pauses while the browser tab is backgrounded
    (`document.hidden`); the first sample just primes the baseline.
-4. **Testable core.** Parsing of `/proc/net/dev` and the "which interface is the
-   box" choice live in pure functions (`www/vpnmgmt/netstat.php`) covered by
-   `tests/test_netstat.php`.
+4. **Testable core.** Parsing of `/proc/net/dev` and `/proc/net/route`, the
+   physical-NIC filter and the WAN/LAN classification all live in pure functions
+   (`www/vpnmgmt/netstat.php`) covered by `tests/test_netstat.php`.
 
 Files: added `www/vpnmgmt/netstat.php`, `www/vpnmgmt/throughput.php`,
 `tests/test_netstat.php`; edited `www/index.php` (panel + poller),

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -52,6 +52,7 @@ fi
 
 echo "== unit tests =="
 php tests/test_vpn_backend.php
+php tests/test_netstat.php
 
 echo
 echo "All checks complete."

--- a/tests/test_netstat.php
+++ b/tests/test_netstat.php
@@ -4,7 +4,8 @@
 // Run:  php tests/test_netstat.php
 //
 // These functions are pure (no I/O, no privileges), so they are exercised
-// directly with sample /proc/net/dev text and interface maps.
+// directly with sample /proc/net/dev and /proc/net/route text and interface
+// maps.
 
 error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED);
 
@@ -44,18 +45,88 @@ check('header lines ignored', !isset($p['Inter-|']) && !isset($p['face']));
 check('empty input -> empty array', tp_parse_proc_net_dev('') === array());
 check('non-string -> empty array', tp_parse_proc_net_dev(null) === array());
 
-// Value adjacent to the colon (long iface name / large counter).
 $jammed = "enp0s3:9999999 1 0 0 0 0 0 0 8888888 1 0 0 0 0 0 0\n";
 $pj = tp_parse_proc_net_dev($jammed);
 check('handles value adjacent to colon',
 	isset($pj['enp0s3']) && $pj['enp0s3']['rx'] === 9999999 && $pj['enp0s3']['tx'] === 8888888);
 
-// A short/garbled row must be skipped, not fatal.
-$short = "  eth0: 12 34\n";
-check('skips malformed (too few columns) row', tp_parse_proc_net_dev($short) === array());
+check('skips malformed (too few columns) row', tp_parse_proc_net_dev("  eth0: 12 34\n") === array());
 
 // ---------------------------------------------------------------------------
-echo "box interface selection\n";
+echo "default-route (outflow NIC) parsing\n";
+
+$route_hdr = "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n";
+// eth0 has the (physical) default; wg0 also advertises a default with a lower
+// metric. We must report the physical NIC, not the VPN tunnel.
+$route1 = $route_hdr
+	. "eth0\t00000000\t0102A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
+	. "eth0\t0002A8C0\t00000000\t0001\t0\t0\t0\t00FFFFFF\t0\t0\t0\n"
+	. "wg0\t00000000\t00000000\t0001\t0\t0\t50\t00000000\t0\t0\t0\n";
+check('returns the physical default iface, not the VPN', tp_parse_default_iface($route1, 'wg0') === 'eth0');
+check('header row is ignored', tp_parse_default_iface($route1, 'wg0') !== 'Iface');
+
+// Two physical defaults: lowest metric wins.
+$route2 = $route_hdr
+	. "eth1\t00000000\t0102A8C0\t0003\t0\t0\t600\t00000000\t0\t0\t0\n"
+	. "eth0\t00000000\t0103A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n";
+check('lowest-metric default wins', tp_parse_default_iface($route2, 'wg0') === 'eth0');
+
+// WAN on a second NIC, LAN-only first NIC (no default on eth0).
+$route3 = $route_hdr
+	. "eth1\t00000000\t0102A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
+	. "eth0\t0002A8C0\t00000000\t0001\t0\t0\t0\t00FFFFFF\t0\t0\t0\n";
+check('identifies WAN on the second NIC', tp_parse_default_iface($route3, 'wg0') === 'eth1');
+
+check('no default route -> empty', tp_parse_default_iface($route_hdr . "eth0\t0002A8C0\t00000000\t0001\t0\t0\t0\t00FFFFFF\t0\t0\t0\n", 'wg0') === '');
+check('empty input -> empty', tp_parse_default_iface('', 'wg0') === '');
+check('garbage -> empty', tp_parse_default_iface("not a route table\n", 'wg0') === '');
+
+// ---------------------------------------------------------------------------
+echo "physical interface detection\n";
+check('eth0 is physical', tp_is_physical_iface('eth0', 'wg0'));
+check('enp3s0 is physical', tp_is_physical_iface('enp3s0', 'wg0'));
+check('wlan0 is physical', tp_is_physical_iface('wlan0', 'wg0'));
+check('loopback is not physical', !tp_is_physical_iface('lo', 'wg0'));
+check('the vpn iface is not physical', !tp_is_physical_iface('wg0', 'wg0'));
+check('docker0 is not physical', !tp_is_physical_iface('docker0', 'wg0'));
+check('veth* is not physical', !tp_is_physical_iface('veth1a2b3c', 'wg0'));
+check('br- bridge is not physical', !tp_is_physical_iface('br-abc123', 'wg0'));
+check('other tun is not physical', !tp_is_physical_iface('tun5', 'wg0'));
+check('other wg is not physical', !tp_is_physical_iface('wg1', 'wg0'));
+
+// ---------------------------------------------------------------------------
+echo "interface classification (outflow WAN vs inflow LAN)\n";
+
+// Single-NIC box: the one physical NIC is the WAN/uplink, no separate LAN rows.
+$c = tp_classify_ifaces(array('lo' => 1, 'wg0' => 1, 'eth0' => 1), 'wg0', 'eth0');
+check('single NIC -> wan=eth0', $c['wan'] === 'eth0');
+check('single NIC -> no LAN rows', $c['lan'] === array());
+
+// Dual-NIC box with a route hint: eth1 is WAN, eth0 is LAN.
+$c = tp_classify_ifaces(array('lo' => 1, 'wg0' => 1, 'eth0' => 1, 'eth1' => 1), 'wg0', 'eth1');
+check('dual NIC -> wan=eth1 (from route)', $c['wan'] === 'eth1');
+check('dual NIC -> lan=[eth0]', $c['lan'] === array('eth0'));
+
+// No route hint: fall back to the name heuristic (prefers ethX).
+$c = tp_classify_ifaces(array('lo' => 1, 'wg0' => 1, 'eth0' => 1, 'eth1' => 1), 'wg0', '');
+check('no hint -> wan falls back to eth0', $c['wan'] === 'eth0');
+check('no hint -> lan=[eth1]', $c['lan'] === array('eth1'));
+
+// Virtual interfaces are excluded entirely.
+$c = tp_classify_ifaces(array('lo' => 1, 'wg0' => 1, 'eth0' => 1, 'docker0' => 1, 'veth9' => 1), 'wg0', 'eth0');
+check('virtual ifaces excluded -> wan=eth0', $c['wan'] === 'eth0');
+check('virtual ifaces excluded -> no LAN rows', $c['lan'] === array());
+
+// Multiple LAN NICs are returned sorted.
+$c = tp_classify_ifaces(array('eth2' => 1, 'eth0' => 1, 'eth1' => 1, 'wg0' => 1, 'lo' => 1), 'wg0', 'eth1');
+check('multiple LAN NICs are sorted', $c['lan'] === array('eth0', 'eth2'));
+
+// A stale/absent route hint still yields a sensible WAN.
+$c = tp_classify_ifaces(array('lo' => 1, 'tun0' => 1, 'wlan0' => 1), 'tun0', 'ppp0');
+check('absent hint -> wan falls back to a present NIC', $c['wan'] === 'wlan0');
+
+// ---------------------------------------------------------------------------
+echo "box interface selection (name heuristic / fallback)\n";
 check('prefers eth0 over vpn and lo',
 	tp_pick_box_iface(array('lo' => 1, 'wg0' => 1, 'eth0' => 1), 'wg0') === 'eth0');
 check('never returns the vpn iface',
@@ -64,12 +135,8 @@ check('falls back to eth0 when nothing suitable present',
 	tp_pick_box_iface(array('lo' => 1, 'wg0' => 1), 'wg0') === 'eth0');
 check('picks enX physical name when no ethX',
 	tp_pick_box_iface(array('lo' => 1, 'tun0' => 1, 'enp0s3' => 1), 'tun0') === 'enp0s3');
-check('picks wlan when only wifi present',
-	tp_pick_box_iface(array('lo' => 1, 'wg0' => 1, 'wlan0' => 1), 'wg0') === 'wlan0');
 check('prefers eth over wlan',
 	tp_pick_box_iface(array('wlan0' => 1, 'eth0' => 1), 'wg0') === 'eth0');
-check('ignores loopback as a candidate',
-	tp_pick_box_iface(array('lo' => 1), 'wg0') === 'eth0');
 
 // ---------------------------------------------------------------------------
 echo "\n";

--- a/tests/test_netstat.php
+++ b/tests/test_netstat.php
@@ -1,0 +1,82 @@
+<?php
+// Unit tests for the throughput helpers (www/vpnmgmt/netstat.php).
+//
+// Run:  php tests/test_netstat.php
+//
+// These functions are pure (no I/O, no privileges), so they are exercised
+// directly with sample /proc/net/dev text and interface maps.
+
+error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED);
+
+require __DIR__ . '/../www/vpnmgmt/netstat.php';
+
+$TESTS = 0;
+$FAILS = 0;
+function check($name, $cond)
+{
+	global $TESTS, $FAILS;
+	$TESTS++;
+	if ($cond) {
+		echo "  PASS  $name\n";
+	} else {
+		$FAILS++;
+		echo "  FAIL  $name\n";
+	}
+}
+
+// ---------------------------------------------------------------------------
+echo "proc/net/dev parsing\n";
+
+$proc = "Inter-|   Receive                                                |  Transmit\n"
+	. " face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n"
+	. "    lo:    1234      12    0    0    0     0          0         0     1234      12    0    0    0     0       0          0\n"
+	. "  eth0: 1000000    5000    0    0    0     0          0         0   200000    4000    0    0    0     0       0          0\n"
+	. "   wg0:  500000    2500    0    0    0     0          0         0   100000    2000    0    0    0     0       0          0\n";
+
+$p = tp_parse_proc_net_dev($proc);
+check('parses all three interfaces', count($p) === 3);
+check('eth0 rx bytes', isset($p['eth0']) && $p['eth0']['rx'] === 1000000);
+check('eth0 tx bytes', isset($p['eth0']) && $p['eth0']['tx'] === 200000);
+check('wg0 rx bytes', isset($p['wg0']) && $p['wg0']['rx'] === 500000);
+check('wg0 tx bytes', isset($p['wg0']) && $p['wg0']['tx'] === 100000);
+check('lo present', isset($p['lo']));
+check('header lines ignored', !isset($p['Inter-|']) && !isset($p['face']));
+check('empty input -> empty array', tp_parse_proc_net_dev('') === array());
+check('non-string -> empty array', tp_parse_proc_net_dev(null) === array());
+
+// Value adjacent to the colon (long iface name / large counter).
+$jammed = "enp0s3:9999999 1 0 0 0 0 0 0 8888888 1 0 0 0 0 0 0\n";
+$pj = tp_parse_proc_net_dev($jammed);
+check('handles value adjacent to colon',
+	isset($pj['enp0s3']) && $pj['enp0s3']['rx'] === 9999999 && $pj['enp0s3']['tx'] === 8888888);
+
+// A short/garbled row must be skipped, not fatal.
+$short = "  eth0: 12 34\n";
+check('skips malformed (too few columns) row', tp_parse_proc_net_dev($short) === array());
+
+// ---------------------------------------------------------------------------
+echo "box interface selection\n";
+check('prefers eth0 over vpn and lo',
+	tp_pick_box_iface(array('lo' => 1, 'wg0' => 1, 'eth0' => 1), 'wg0') === 'eth0');
+check('never returns the vpn iface',
+	tp_pick_box_iface(array('lo' => 1, 'wg0' => 1), 'wg0') !== 'wg0');
+check('falls back to eth0 when nothing suitable present',
+	tp_pick_box_iface(array('lo' => 1, 'wg0' => 1), 'wg0') === 'eth0');
+check('picks enX physical name when no ethX',
+	tp_pick_box_iface(array('lo' => 1, 'tun0' => 1, 'enp0s3' => 1), 'tun0') === 'enp0s3');
+check('picks wlan when only wifi present',
+	tp_pick_box_iface(array('lo' => 1, 'wg0' => 1, 'wlan0' => 1), 'wg0') === 'wlan0');
+check('prefers eth over wlan',
+	tp_pick_box_iface(array('wlan0' => 1, 'eth0' => 1), 'wg0') === 'eth0');
+check('ignores loopback as a candidate',
+	tp_pick_box_iface(array('lo' => 1), 'wg0') === 'eth0');
+
+// ---------------------------------------------------------------------------
+echo "\n";
+if ($FAILS === 0) {
+	echo "ALL $TESTS TESTS PASSED\n";
+	exit(0);
+}
+echo "$FAILS of $TESTS TESTS FAILED\n";
+exit(1);
+?>

--- a/www/index.css
+++ b/www/index.css
@@ -664,3 +664,21 @@ footer{
         font-size: 80%;
 }
 
+#ThroughputTable .tprole {
+        color: #808080;
+        font-size: 80%;
+        font-style: italic;
+}
+
+#ThroughputTable tr.tprole-vpn td.tplabel strong { color: #2e7d32; }
+#ThroughputTable tr.tprole-wan td.tplabel strong { color: #1565c0; }
+#ThroughputTable tr.tprole-lan td.tplabel strong { color: #6a1b9a; }
+
+.tplegend {
+        font-family: "Arial";
+        font-size: 12px;
+        color: #4d4d4d;
+        margin: 4px 0 0 2%;
+        padding: 0;
+}
+

--- a/www/index.css
+++ b/www/index.css
@@ -607,3 +607,60 @@ footer{
         z-index: 99;
 }
 
+#ThroughputSection {
+        width: 100%;
+        background-color: #E6E6E6;
+        padding-top: 5px;
+        padding-bottom: 8px;
+}
+
+#ThroughputSection H2 {
+        padding-top: 10px;
+        padding-left: 10px;
+        margin-top: 0;
+        margin-bottom: 5px;
+}
+
+#ThroughputTable {
+        width: 96%;
+        margin-left: 2%;
+        border-collapse: collapse;
+        table-layout: fixed;
+        font-family: "Arial";
+}
+
+#ThroughputTable th {
+        text-align: right;
+        font-family: "Arial";
+        font-size: 90%;
+        color: #4d4d4d;
+        padding: 6px 10px;
+        border-bottom: 1px solid #CCCCCC;
+}
+
+#ThroughputTable th.tpwhat {
+        text-align: left;
+}
+
+#ThroughputTable td {
+        padding: 6px 10px;
+        font-family: "Arial";
+        border-bottom: 1px solid #D9D9D9;
+}
+
+#ThroughputTable td.tplabel {
+        text-align: left;
+}
+
+#ThroughputTable td.tprate {
+        text-align: right;
+        font-family: "Courier";
+        font-weight: bold;
+        white-space: nowrap;
+}
+
+#ThroughputTable .tpiface {
+        color: #808080;
+        font-size: 80%;
+}
+

--- a/www/index.php
+++ b/www/index.php
@@ -333,28 +333,24 @@ echo "window.history.pushState('','','/');";
 		<div id="ThroughputSection">
 			<H2>Throughput</H2>
 			<table id="ThroughputTable">
-				<tr>
-					<th class="tpwhat"></th>
-					<th>&#8595; Download</th>
-					<th>&#8593; Upload</th>
-				</tr>
-				<tr>
-					<td class="tplabel">VPN tunnel <span class="tpiface" id="tpVpnIface"></span></td>
-					<td class="tprate" id="tpVpnRx">&hellip;</td>
-					<td class="tprate" id="tpVpnTx">&hellip;</td>
-				</tr>
-				<tr>
-					<td class="tplabel">Whole box <span class="tpiface" id="tpBoxIface"></span></td>
-					<td class="tprate" id="tpBoxRx">&hellip;</td>
-					<td class="tprate" id="tpBoxTx">&hellip;</td>
-				</tr>
+				<thead>
+					<tr>
+						<th class="tpwhat">Interface</th>
+						<th>&#8595; RX (in)</th>
+						<th>&#8593; TX (out)</th>
+					</tr>
+				</thead>
+				<tbody id="tpBody">
+					<tr><td class="tplabel">&hellip;</td><td class="tprate">&hellip;</td><td class="tprate">&hellip;</td></tr>
+				</tbody>
 			</table>
+			<p class="tplegend"><strong>WAN</strong> = internet uplink (outflow) &middot; <strong>LAN</strong> = client-facing (inflow) &middot; <strong>VPN</strong> = encrypted tunnel. Per-interface RX (received) / TX (transmitted) by the gateway.</p>
 		</div>
 		<script type="text/javascript">
 		// Live throughput meter. Polls throughput.php for cumulative byte
 		// counters and derives the rate from successive samples on the client.
 		(function(){
-			var prev = null;          // previous sample
+			var prev = null;          // previous sample: { t, m: { iface: {rx,tx} } }
 			var POLL_MS = 2000;
 
 			function tpFmt(bps){
@@ -373,30 +369,40 @@ echo "window.history.pushState('','','/');";
 				return d / dtSec;
 			}
 
+			// Role -> display word + descriptor. On a single-NIC box the uplink
+			// also carries LAN traffic, so it is labelled WAN/LAN.
+			function roleMeta(role, multi){
+				if (role === "vpn") return { word: "VPN", desc: "tunnel" };
+				if (role === "wan") return multi ? { word: "WAN", desc: "outflow" }
+				                                 : { word: "WAN/LAN", desc: "uplink" };
+				return { word: "LAN", desc: "inflow" };
+			}
+
+			function cellRate(r, pm, dt, which){
+				if (r.role === "vpn" && !r.up) return (which === "rx") ? "VPN off" : "&mdash;";
+				if (!r.up || r[which] === null) return "&mdash;";
+				if (pm && pm[r.iface] && dt > 0) return tpFmt(rate(r[which], pm[r.iface][which], dt));
+				return "&hellip;";
+			}
+
 			function tick(){
 				if (document.hidden) return;   // skip when tab is backgrounded
 				$.getJSON("throughput.php", function(s){
-					$("#tpVpnIface").text(s.vpn.iface ? "(" + s.vpn.iface + ")" : "");
-					$("#tpBoxIface").text(s.box.iface ? "(" + s.box.iface + ")" : "");
-
-					if (prev && s.t > prev.t){
-						var dt = (s.t - prev.t) / 1000.0;
-						if (s.vpn.up && s.vpn.rx !== null){
-							$("#tpVpnRx").html(tpFmt(rate(s.vpn.rx, prev.vpn.rx, dt)));
-							$("#tpVpnTx").html(tpFmt(rate(s.vpn.tx, prev.vpn.tx, dt)));
-						} else {
-							$("#tpVpnRx").html("VPN off");
-							$("#tpVpnTx").html("&mdash;");
-						}
-						if (s.box.up && s.box.rx !== null){
-							$("#tpBoxRx").html(tpFmt(rate(s.box.rx, prev.box.rx, dt)));
-							$("#tpBoxTx").html(tpFmt(rate(s.box.tx, prev.box.tx, dt)));
-						} else {
-							$("#tpBoxRx").html("&mdash;");
-							$("#tpBoxTx").html("&mdash;");
-						}
+					var dt = (prev && s.t > prev.t) ? (s.t - prev.t) / 1000.0 : 0;
+					var pm = prev ? prev.m : null;
+					var html = "", m = {};
+					for (var i = 0; i < s.rows.length; i++){
+						var r = s.rows[i], meta = roleMeta(r.role, s.multi);
+						html += '<tr class="tprow tprole-' + r.role + '">'
+						      + '<td class="tplabel"><strong>' + meta.word + '</strong> '
+						      + '<span class="tpiface">' + r.iface + '</span> '
+						      + '<span class="tprole">' + meta.desc + '</span></td>'
+						      + '<td class="tprate">' + cellRate(r, pm, dt, "rx") + '</td>'
+						      + '<td class="tprate">' + cellRate(r, pm, dt, "tx") + '</td></tr>';
+						m[r.iface] = { rx: r.rx, tx: r.tx };
 					}
-					prev = s;
+					$("#tpBody").html(html);
+					prev = { t: s.t, m: m };
 				});
 			}
 

--- a/www/index.php
+++ b/www/index.php
@@ -330,6 +330,79 @@ echo "window.history.pushState('','','/');";
 		<div id="CurrentVPNSection">
 			<script>$(function(){$("#CurrentVPNSection").load("currentvpnsection.php");}); </script> 
 		</div>
+		<div id="ThroughputSection">
+			<H2>Throughput</H2>
+			<table id="ThroughputTable">
+				<tr>
+					<th class="tpwhat"></th>
+					<th>&#8595; Download</th>
+					<th>&#8593; Upload</th>
+				</tr>
+				<tr>
+					<td class="tplabel">VPN tunnel <span class="tpiface" id="tpVpnIface"></span></td>
+					<td class="tprate" id="tpVpnRx">&hellip;</td>
+					<td class="tprate" id="tpVpnTx">&hellip;</td>
+				</tr>
+				<tr>
+					<td class="tplabel">Whole box <span class="tpiface" id="tpBoxIface"></span></td>
+					<td class="tprate" id="tpBoxRx">&hellip;</td>
+					<td class="tprate" id="tpBoxTx">&hellip;</td>
+				</tr>
+			</table>
+		</div>
+		<script type="text/javascript">
+		// Live throughput meter. Polls throughput.php for cumulative byte
+		// counters and derives the rate from successive samples on the client.
+		(function(){
+			var prev = null;          // previous sample
+			var POLL_MS = 2000;
+
+			function tpFmt(bps){
+				if (bps === null || isNaN(bps)) return "&mdash;";
+				if (bps < 0) bps = 0;
+				var u = ["B/s","KB/s","MB/s","GB/s"], i = 0, v = bps;
+				while (v >= 1024 && i < u.length - 1){ v = v / 1024; i++; }
+				var dp = (i === 0) ? 0 : (v < 10 ? 1 : 0);
+				return v.toFixed(dp) + " " + u[i];
+			}
+
+			function rate(cur, old, dtSec){
+				if (cur === null || old === null) return null;
+				var d = cur - old;
+				if (d < 0) return null;   // counter reset (interface bounced)
+				return d / dtSec;
+			}
+
+			function tick(){
+				if (document.hidden) return;   // skip when tab is backgrounded
+				$.getJSON("throughput.php", function(s){
+					$("#tpVpnIface").text(s.vpn.iface ? "(" + s.vpn.iface + ")" : "");
+					$("#tpBoxIface").text(s.box.iface ? "(" + s.box.iface + ")" : "");
+
+					if (prev && s.t > prev.t){
+						var dt = (s.t - prev.t) / 1000.0;
+						if (s.vpn.up && s.vpn.rx !== null){
+							$("#tpVpnRx").html(tpFmt(rate(s.vpn.rx, prev.vpn.rx, dt)));
+							$("#tpVpnTx").html(tpFmt(rate(s.vpn.tx, prev.vpn.tx, dt)));
+						} else {
+							$("#tpVpnRx").html("VPN off");
+							$("#tpVpnTx").html("&mdash;");
+						}
+						if (s.box.up && s.box.rx !== null){
+							$("#tpBoxRx").html(tpFmt(rate(s.box.rx, prev.box.rx, dt)));
+							$("#tpBoxTx").html(tpFmt(rate(s.box.tx, prev.box.tx, dt)));
+						} else {
+							$("#tpBoxRx").html("&mdash;");
+							$("#tpBoxTx").html("&mdash;");
+						}
+					}
+					prev = s;
+				});
+			}
+
+			$(function(){ tick(); setInterval(tick, POLL_MS); });
+		})();
+		</script>
 		<div id="VPNChooser">
 		<H2>Choose new VPN server:</H2>
 			<div id="ChooseVPNBasic">

--- a/www/vpnmgmt/netstat.php
+++ b/www/vpnmgmt/netstat.php
@@ -2,14 +2,15 @@
 // ---------------------------------------------------------------------------
 // Network throughput helpers.
 //
-// Pure, side-effect-free functions used by throughput.php to report interface
-// byte counters. Counters come from /proc/net/dev, which is world-readable, so
-// the throughput meter needs no elevated privileges (no sudo, no firewall or
-// service changes).
+// Pure, side-effect-free functions used by throughput.php to report per-NIC
+// byte counters. Counters come from /proc/net/dev and the route table from
+// /proc/net/route, both world-readable, so the throughput meter needs no
+// elevated privileges (no sudo, no firewall or service changes).
 //
 // Rates are computed on the client from two successive samples; these helpers
-// only parse the cumulative counters and decide which interface represents
-// "the whole box". Keeping the logic here (free of I/O) makes it unit-testable.
+// only parse the cumulative counters and classify each interface as the VPN
+// tunnel, the outflow/WAN NIC (the internet uplink) or an inflow/LAN NIC
+// (client-facing). Keeping the logic here (free of I/O) makes it unit-testable.
 // ---------------------------------------------------------------------------
 
 // Parse the contents of /proc/net/dev into:
@@ -25,14 +26,16 @@ function tp_parse_proc_net_dev($text)
 	foreach (preg_split('/\R/u', $text) as $line) {
 		// Data lines look like:  "  eth0: 12345 67 0 ... 8910 11 ..."
 		// The interface name is everything before the first colon; the header
-		// lines ("Inter-|...", " face |...") have their pipe before any colon.
+		// lines ("Inter-|...", " face |...") have no colon in that position.
 		$pos = strpos($line, ':');
 		if ($pos === false) {
 			continue;
 		}
 		$iface = trim(substr($line, 0, $pos));
-		if ($iface === '' || strpos($iface, '|') !== false || strpos($iface, ' ') !== false) {
-			continue; // not a real interface name
+		// Real interface names are a restricted character set; this also drops
+		// the header rows (which contain '|' or spaces).
+		if (!preg_match('/^[A-Za-z0-9._:-]+$/', $iface)) {
+			continue;
 		}
 		$fields = preg_split('/\s+/', trim(substr($line, $pos + 1)));
 		// Per the kernel column layout, after the colon:
@@ -50,16 +53,78 @@ function tp_parse_proc_net_dev($text)
 	return $out;
 }
 
-// Choose the interface that best represents "the whole box": the primary
-// physical uplink. Preference order:
-//   1) a present interface named like a physical NIC (eth*, en*, wlan*, wl*),
-//   2) any other real interface,
-// never the VPN interface or loopback. Falls back to 'eth0' (this project's
-// documented default) when nothing suitable is present.
+// Parse /proc/net/route and return the interface of the main-table default
+// route (destination 0.0.0.0/0) with the lowest metric -- i.e. the physical
+// uplink the box uses to reach the internet. The VPN interface and loopback are
+// ignored so we report the *physical* outflow NIC even while the tunnel owns
+// the effective default route. Returns '' if none is found.
+//
+// Note: wg-quick (AllowedIPs 0.0.0.0/0, via fwmark) and OpenVPN redirect-gateway
+// both leave the main-table default pointing at the physical uplink, so this
+// correctly identifies the WAN NIC in the common cases.
+function tp_parse_default_iface($text, $vpn_iface)
+{
+	if (!is_string($text) || $text === '') {
+		return '';
+	}
+	$best = '';
+	$best_metric = PHP_INT_MAX;
+	foreach (preg_split('/\R/u', $text) as $line) {
+		$line = trim($line);
+		if ($line === '') {
+			continue;
+		}
+		$f = preg_split('/\s+/', $line);
+		if (count($f) < 8) {
+			continue;
+		}
+		// Skip the header row (Destination column is the literal word).
+		if (!ctype_xdigit($f[1]) || !ctype_xdigit($f[7])) {
+			continue;
+		}
+		// Default route = destination 0.0.0.0 with mask 0.0.0.0.
+		if (strcasecmp($f[1], '00000000') !== 0 || strcasecmp($f[7], '00000000') !== 0) {
+			continue;
+		}
+		$iface = $f[0];
+		if ($iface === $vpn_iface || $iface === 'lo') {
+			continue;
+		}
+		$metric = is_numeric($f[6]) ? (int) $f[6] : 0;
+		if ($metric < $best_metric) {
+			$best_metric = $metric;
+			$best = $iface;
+		}
+	}
+	return $best;
+}
+
+// Is $name a physical-ish NIC we want to report (not loopback, not the VPN
+// tunnel, not a virtual/bridge/container interface)?
+function tp_is_physical_iface($name, $vpn_iface)
+{
+	if ($name === 'lo' || $name === $vpn_iface) {
+		return false;
+	}
+	$virtual_prefixes = array(
+		'veth', 'docker', 'br-', 'virbr', 'vmnet',
+		'tap', 'tun', 'wg', 'sit', 'ip6tnl', 'gre', 'dummy', 'kube',
+	);
+	foreach ($virtual_prefixes as $p) {
+		if (strncmp($name, $p, strlen($p)) === 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Choose the interface that best represents the primary physical uplink, by
+// name, when the route table doesn't tell us (fallback for tp_classify_ifaces).
+// Preference: eth*, en*, wlan*, wl*; never the VPN interface or loopback; then
+// any other interface; finally 'eth0'.
 function tp_pick_box_iface(array $ifaces, $vpn_iface)
 {
 	$names = array_keys($ifaces);
-
 	foreach (array('/^eth/', '/^en/', '/^wlan/', '/^wl/') as $pat) {
 		foreach ($names as $n) {
 			if ($n === $vpn_iface || $n === 'lo') {
@@ -77,5 +142,35 @@ function tp_pick_box_iface(array $ifaces, $vpn_iface)
 		return $n;
 	}
 	return 'eth0';
+}
+
+// Classify the physical interfaces into the outflow/WAN NIC and the inflow/LAN
+// NICs. $wan_hint is the default-route interface from tp_parse_default_iface().
+// Returns ['wan' => <name|''>, 'lan' => [<name>, ...]] with LAN sorted.
+function tp_classify_ifaces(array $ifaces, $vpn_iface, $wan_hint)
+{
+	$phys = array();
+	foreach (array_keys($ifaces) as $n) {
+		if (tp_is_physical_iface($n, $vpn_iface)) {
+			$phys[] = $n;
+		}
+	}
+	sort($phys);
+
+	$wan = '';
+	if ($wan_hint !== '' && in_array($wan_hint, $phys, true)) {
+		$wan = $wan_hint;            // the real default-route NIC
+	} elseif (!empty($phys)) {
+		$cand = tp_pick_box_iface($ifaces, $vpn_iface);  // name-based fallback
+		$wan = in_array($cand, $phys, true) ? $cand : $phys[0];
+	}
+
+	$lan = array();
+	foreach ($phys as $n) {
+		if ($n !== $wan) {
+			$lan[] = $n;
+		}
+	}
+	return array('wan' => $wan, 'lan' => $lan);
 }
 ?>

--- a/www/vpnmgmt/netstat.php
+++ b/www/vpnmgmt/netstat.php
@@ -1,0 +1,81 @@
+<?php
+// ---------------------------------------------------------------------------
+// Network throughput helpers.
+//
+// Pure, side-effect-free functions used by throughput.php to report interface
+// byte counters. Counters come from /proc/net/dev, which is world-readable, so
+// the throughput meter needs no elevated privileges (no sudo, no firewall or
+// service changes).
+//
+// Rates are computed on the client from two successive samples; these helpers
+// only parse the cumulative counters and decide which interface represents
+// "the whole box". Keeping the logic here (free of I/O) makes it unit-testable.
+// ---------------------------------------------------------------------------
+
+// Parse the contents of /proc/net/dev into:
+//   [ 'eth0' => ['rx' => <bytes>, 'tx' => <bytes>], ... ]
+// Only the cumulative receive/transmit byte columns are kept. Header lines and
+// malformed rows are ignored.
+function tp_parse_proc_net_dev($text)
+{
+	$out = array();
+	if (!is_string($text) || $text === '') {
+		return $out;
+	}
+	foreach (preg_split('/\R/u', $text) as $line) {
+		// Data lines look like:  "  eth0: 12345 67 0 ... 8910 11 ..."
+		// The interface name is everything before the first colon; the header
+		// lines ("Inter-|...", " face |...") have their pipe before any colon.
+		$pos = strpos($line, ':');
+		if ($pos === false) {
+			continue;
+		}
+		$iface = trim(substr($line, 0, $pos));
+		if ($iface === '' || strpos($iface, '|') !== false || strpos($iface, ' ') !== false) {
+			continue; // not a real interface name
+		}
+		$fields = preg_split('/\s+/', trim(substr($line, $pos + 1)));
+		// Per the kernel column layout, after the colon:
+		//   receive:  bytes packets errs drop fifo frame compressed multicast
+		//   transmit: bytes packets errs drop fifo colls carrier compressed
+		// so receive bytes = field 0 and transmit bytes = field 8 (0-indexed).
+		if (count($fields) < 9 || !is_numeric($fields[0]) || !is_numeric($fields[8])) {
+			continue;
+		}
+		$out[$iface] = array(
+			'rx' => (int) $fields[0],
+			'tx' => (int) $fields[8],
+		);
+	}
+	return $out;
+}
+
+// Choose the interface that best represents "the whole box": the primary
+// physical uplink. Preference order:
+//   1) a present interface named like a physical NIC (eth*, en*, wlan*, wl*),
+//   2) any other real interface,
+// never the VPN interface or loopback. Falls back to 'eth0' (this project's
+// documented default) when nothing suitable is present.
+function tp_pick_box_iface(array $ifaces, $vpn_iface)
+{
+	$names = array_keys($ifaces);
+
+	foreach (array('/^eth/', '/^en/', '/^wlan/', '/^wl/') as $pat) {
+		foreach ($names as $n) {
+			if ($n === $vpn_iface || $n === 'lo') {
+				continue;
+			}
+			if (preg_match($pat, $n)) {
+				return $n;
+			}
+		}
+	}
+	foreach ($names as $n) {
+		if ($n === $vpn_iface || $n === 'lo') {
+			continue;
+		}
+		return $n;
+	}
+	return 'eth0';
+}
+?>

--- a/www/vpnmgmt/throughput.php
+++ b/www/vpnmgmt/throughput.php
@@ -1,12 +1,17 @@
 <?php
 // AJAX endpoint for the live throughput meter. Returns the current cumulative
-// byte counters (plus a server timestamp) for the VPN interface and the primary
-// physical interface ("the whole box"). The browser samples this every couple
-// of seconds and derives the rate from successive samples, so there is no
-// server-side state and no blocking sleep.
+// byte counters (plus a server timestamp) for every relevant interface, each
+// tagged with its role:
+//   vpn  - the VPN tunnel (wg0 / tun0)
+//   wan  - the outflow NIC: the physical uplink to the internet
+//   lan  - an inflow NIC: a client-facing physical interface
+// The browser samples this every couple of seconds and derives the rate from
+// successive samples, so there is no server-side state and no blocking sleep.
 //
-// Reads /proc/net/dev (world-readable) only, so no elevated privileges are
-// required and nothing about the firewall / kill switch is touched.
+// Reads /proc/net/dev and /proc/net/route (both world-readable) only, so no
+// elevated privileges are required and nothing about the firewall/kill switch
+// or services is touched. On a single-NIC box there are no separate LAN rows;
+// the one physical NIC is reported as the WAN/uplink.
 
 require_once(__DIR__ . '/vpn_backend.php');
 require_once(__DIR__ . '/netstat.php');
@@ -17,28 +22,48 @@ header('Cache-Control: no-store');
 $raw    = @file_get_contents('/proc/net/dev');
 $ifaces = tp_parse_proc_net_dev($raw === false ? '' : $raw);
 
+$routes   = @file_get_contents('/proc/net/route');
 $vpn_iface = vpn_iface();
-$box_iface = tp_pick_box_iface($ifaces, $vpn_iface);
+$wan_hint  = tp_parse_default_iface($routes === false ? '' : $routes, $vpn_iface);
+$cls       = tp_classify_ifaces($ifaces, $vpn_iface, $wan_hint);
 
-$vpn_has = isset($ifaces[$vpn_iface]);
-$box_has = isset($ifaces[$box_iface]);
+// Helper to build one row for an interface.
+$row = function ($role, $iface) use ($ifaces) {
+	$has = isset($ifaces[$iface]);
+	return array(
+		'role'  => $role,
+		'iface' => $iface,
+		'up'    => $has,
+		'rx'    => $has ? $ifaces[$iface]['rx'] : null,
+		'tx'    => $has ? $ifaces[$iface]['tx'] : null,
+	);
+};
 
-$resp = array(
-	't'   => (int) round(microtime(true) * 1000), // ms on the server clock
-	'vpn' => array(
-		'iface' => $vpn_iface,
-		// "up" when the tunnel interface exists and the gateway isn't disabled.
-		'up'    => $vpn_has && !vpn_is_disabled(),
-		'rx'    => $vpn_has ? $ifaces[$vpn_iface]['rx'] : null,
-		'tx'    => $vpn_has ? $ifaces[$vpn_iface]['tx'] : null,
-	),
-	'box' => array(
-		'iface' => $box_iface,
-		'up'    => $box_has,
-		'rx'    => $box_has ? $ifaces[$box_iface]['rx'] : null,
-		'tx'    => $box_has ? $ifaces[$box_iface]['tx'] : null,
-	),
+$rows = array();
+
+// VPN tunnel first. "up" also requires the gateway not to be disabled.
+$vpn_has   = isset($ifaces[$vpn_iface]);
+$rows[]    = array(
+	'role'  => 'vpn',
+	'iface' => $vpn_iface,
+	'up'    => $vpn_has && !vpn_is_disabled(),
+	'rx'    => $vpn_has ? $ifaces[$vpn_iface]['rx'] : null,
+	'tx'    => $vpn_has ? $ifaces[$vpn_iface]['tx'] : null,
 );
 
-echo json_encode($resp);
+// Outflow / WAN NIC.
+if ($cls['wan'] !== '') {
+	$rows[] = $row('wan', $cls['wan']);
+}
+
+// Inflow / LAN NIC(s).
+foreach ($cls['lan'] as $lan_iface) {
+	$rows[] = $row('lan', $lan_iface);
+}
+
+echo json_encode(array(
+	't'     => (int) round(microtime(true) * 1000), // ms on the server clock
+	'multi' => count($cls['lan']) > 0,               // true when LAN NICs are distinct
+	'rows'  => $rows,
+));
 ?>

--- a/www/vpnmgmt/throughput.php
+++ b/www/vpnmgmt/throughput.php
@@ -1,0 +1,44 @@
+<?php
+// AJAX endpoint for the live throughput meter. Returns the current cumulative
+// byte counters (plus a server timestamp) for the VPN interface and the primary
+// physical interface ("the whole box"). The browser samples this every couple
+// of seconds and derives the rate from successive samples, so there is no
+// server-side state and no blocking sleep.
+//
+// Reads /proc/net/dev (world-readable) only, so no elevated privileges are
+// required and nothing about the firewall / kill switch is touched.
+
+require_once(__DIR__ . '/vpn_backend.php');
+require_once(__DIR__ . '/netstat.php');
+
+header('Content-Type: application/json');
+header('Cache-Control: no-store');
+
+$raw    = @file_get_contents('/proc/net/dev');
+$ifaces = tp_parse_proc_net_dev($raw === false ? '' : $raw);
+
+$vpn_iface = vpn_iface();
+$box_iface = tp_pick_box_iface($ifaces, $vpn_iface);
+
+$vpn_has = isset($ifaces[$vpn_iface]);
+$box_has = isset($ifaces[$box_iface]);
+
+$resp = array(
+	't'   => (int) round(microtime(true) * 1000), // ms on the server clock
+	'vpn' => array(
+		'iface' => $vpn_iface,
+		// "up" when the tunnel interface exists and the gateway isn't disabled.
+		'up'    => $vpn_has && !vpn_is_disabled(),
+		'rx'    => $vpn_has ? $ifaces[$vpn_iface]['rx'] : null,
+		'tx'    => $vpn_has ? $ifaces[$vpn_iface]['tx'] : null,
+	),
+	'box' => array(
+		'iface' => $box_iface,
+		'up'    => $box_has,
+		'rx'    => $box_has ? $ifaces[$box_iface]['rx'] : null,
+		'tx'    => $box_has ? $ifaces[$box_iface]['tx'] : null,
+	),
+);
+
+echo json_encode($resp);
+?>


### PR DESCRIPTION
## Summary

Adds a live **Throughput** panel to the management web page (under "Current VPN server"), updating every ~2s with per-interface RX/TX rates. Each row is tagged by **role** so it's clear which NIC is the internet uplink vs. the client-facing side:

- **VPN tunnel** — the active VPN interface (`wg0`/`tun0`); shows "VPN off" when the gateway is disabled.
- **WAN · outflow** — the physical uplink to the internet, identified as the interface holding the main-table default route (`/proc/net/route`). The VPN tunnel is ignored, so the *physical* NIC is reported even while the tunnel owns the effective default route.
- **LAN · inflow** — every other physical NIC (client-facing); one row each on a multi-NIC box.

On a **single-NIC** box there's just one physical NIC, reported as **WAN/LAN (uplink)** since it carries both. Virtual/bridge/container interfaces (`lo`, `veth*`, `docker*`, `br-*`, other `tun*`/`wg*`, …) are excluded.

## How it works

- **No new privileges.** Counters come from `/proc/net/dev` and the route table from `/proc/net/route` — both world-readable. No `sudo`, no firewall/kill-switch or service changes, backend-agnostic.
- **Rates computed client-side.** `throughput.php` returns role-tagged per-interface rows (cumulative byte counters + a server timestamp) as JSON. The page keeps the previous sample keyed by interface name and derives `Δbytes / Δt` — no server-side state, no blocking `sleep`.
- **Robust.** Negative deltas (counter resets when an interface bounces) are suppressed; polling pauses while the tab is backgrounded (`document.hidden`); the first sample primes the baseline; rows render dynamically for any NIC count.
- **Testable core.** `/proc/net/dev` + `/proc/net/route` parsing, the physical-NIC filter, and the WAN/LAN classification are pure functions in `netstat.php`.

## Files

- **Added:** `www/vpnmgmt/netstat.php` (pure helpers: `tp_parse_proc_net_dev`, `tp_parse_default_iface`, `tp_is_physical_iface`, `tp_classify_ifaces`, `tp_pick_box_iface`), `www/vpnmgmt/throughput.php` (JSON endpoint), `tests/test_netstat.php`.
- **Changed:** `www/index.php` (panel + poller), `www/index.css` (panel/role styles), `tests/run.sh`, `README.md`, `documentation/IMPLEMENTATION_NOTES.md`.

## QA

- `tests/run.sh`: PHP lint OK, `bash -n` OK, `xmllint` OK, unit tests **79/79 PASS** (36 existing + 43 throughput).
- Smoke-tested the endpoint against a real `/proc/net/dev` + `/proc/net/route`: valid JSON; on this single-NIC host it correctly emits `vpn(tun0, down)` + `wan(eth0, live counters)`, `multi:false`. The classifier's multi-NIC paths (WAN-from-route, sorted LAN rows, virtual-iface exclusion, fallbacks) are covered by unit tests.

🤖 Generated with [Claude Code](https://claude.ai/code/session_01KX8zZ9XvFx9iTV2qzZTmTp)